### PR TITLE
bootstrap based url config tool

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Click==7.0
 coverage==4.5.3
 ddt==1.2.1
 Flask==1.0.2
-Flask-Bootstrap==3.3.7.1
+Flask-Bootstrap4==4.0.2
 gunicorn==19.9.0
 pytest==5.4.1
 requests==2.21.0

--- a/src/templates/config.html
+++ b/src/templates/config.html
@@ -1,0 +1,107 @@
+{% extends "bootstrap/base.html" %}
+{% block title %}ATIS url configuration tool{% endblock %}
+
+{% block content %}
+<div class="jumbotron jumbotron-fluid">
+  <div class="container">
+    <h1 class="display-4">ATIS url configuration tool</h1>
+
+    <label class="control-label">METAR source</label>
+    <div class="control-group">
+      <div class="form-check form-check-inline">
+        <input onchange="selectionChanged()" class="form-check-input" type="radio" id="metar_euroscope" name="metarSource" checked>
+        <label class="form-check-label" for="metar_euroscope">Euroscope</label>
+      </div>
+      <div class="form-check form-check-inline">
+        <input onchange="selectionChanged()" class="form-check-input" type="radio" id="metar_ipma" name="metarSource">
+        <label class="form-check-label" for="metar_ipma">IPMA</label>
+      </div>
+    </div>
+    <hr class="my-4">
+
+    <label class="control-label">Global options</label>
+    <div class="control-group">
+      <div class="form-check">
+        <input onchange="selectionChanged()" class="form-check-input" type="checkbox" id="show_freqs" checked>
+        <label class="form-check-label" for="show_freqs">
+          Show ATC frequencies
+        </label>
+      </div>
+    </div>
+    <hr class="my-4">
+
+    <label class="control-label">LPPT options</label>
+    <div class="control-group">
+      <div class="form-check">
+        <input onchange="selectionChanged()" class="form-check-input" type="checkbox" value="" id="hiro">
+        <label class="form-check-label" for="hiro">
+          High intensity runway operations
+        </label>
+      </div>
+      <div class="form-check">
+        <input onchange="selectionChanged()" class="form-check-input" type="checkbox" value="" id="rwy_35_clsd">
+        <label class="form-check-label" for="rwy_35_clsd">
+          Runway 35 closed
+        </label>
+      </div>
+      <div class="form-check">
+        <input onchange="selectionChanged()" class="form-check-input" type="checkbox" value="" id="xpndr_startup">
+        <label class="form-check-label" for="xpndr_startup">
+          Expect transponder only at startup
+        </label>
+      </div>
+    </div>
+    <hr class="my-4">
+
+    <label class="control-label">URL for Euroscope</label>
+    <div class="input-group margin-bottom">
+      <input type="text" class="form-control addon-inline" id="atis_url" readonly>
+      <span class="input-group-btn">
+          <input type="button" class="btn btn-default" onclick="copyToClipboard()" value="Copy">
+      </span>
+    </div>
+    <!-- <hr class="my-4">
+
+    <label class="control-label">Sample ATIS</label>
+    <div class="input-group margin-bottom">
+      <p class="form-control addon-inline" id="atis_text">[LPPT ATIS] [A] 1430 [EXP ILS APCH] [RWY IN USE 03] [TL] 55 [EXP XPNDR ONLY AT STARTUP] [FOR DEP CLEARANCE CONTACT GND 121.750] [AFTER DEP CONTACT 125.55] [AFTER LANDING VACATE VIA HN] [WND] 210 [DEG] 17 [KT] [CLD] [SCT] {2200} [FT] [TEMP] 17 [DP] 11 [QNH] 1008 [COMPLY WITH SPEED LIMITATIONS UNLESS OTHERWISE ADVISED BY ATC] [ACK LPPT INFO] [A]</p>
+    </div> -->
+
+  </div>
+</div>
+
+<script type="application/javascript">
+  function selectionChanged() {
+    let metar = document.getElementById('metar_euroscope').checked ? 'metar=$metar($atisairport)' : 'metar=$atisairport';
+    let options = _computeOptions(['show_freqs', 'hiro', 'rwy_35_clsd', 'xpndr_startup'])
+
+    document.getElementById('atis_url').value = _computeUrl(metar, '$arrrwy($atisairport)', '$atiscode', options);
+  }
+
+  function _computeOptions(options) {
+    var result = '';
+
+    options.forEach(option => {
+      result += `&${option}=${document.getElementById(option).checked}`;
+    });
+
+    return result;
+  }
+
+  function _computeUrl(metar, rwy, letter, options) {
+    return `https://atis-pt.herokuapp.com/?${metar}&rwy=${rwy}&letter=${letter}${options}`;
+  }
+
+  function copyToClipboard() {
+    var atisUrl = document.getElementById("atis_url");
+
+    atisUrl.select();
+    atisUrl.setSelectionRange(0, 99999);
+
+    document.execCommand("copy");
+  }
+
+  document.onload = selectionChanged();
+</script>
+
+{% endblock %}

--- a/src/web.py
+++ b/src/web.py
@@ -31,6 +31,10 @@ from . import metar_sources
 app = Flask(__name__)
 Bootstrap(app)
 
+@app.route('/config')
+def config():
+    return render_template('config.html')
+
 @app.route('/metar')
 def metar():
     if 'icao' not in request.args:


### PR DESCRIPTION
Currently the optional features of the ATIS are badly documented and there is little to no information on how to use them.

This provides a browser based tool to configure the ATIS url by selecting the desired features from a list of available options.

Would be available at: https://atis-pt.herokuapp.com/config

![image](https://user-images.githubusercontent.com/1645623/79360925-825b2c80-7f3c-11ea-9c85-1c7b47732306.png)
