### PR TITLE
Corrected LPFR approach rwy 28

### DIFF
--- a/src/settings.py
+++ b/src/settings.py
@@ -69,7 +69,7 @@ ADVISE BEFORE TAX]',
 LPFR = {
     'approaches': {
         '10': 'EXP ILS Z APCH',
-        '28': 'EXP ILS APCH'
+        '28': 'EXP ILS Z APCH'
     },
     'arrdep_info': {
         '10': [],


### PR DESCRIPTION
Changed from ILS to ILS Z at LPFR for rwy 28 according to latest ATIS.